### PR TITLE
feat: stats command

### DIFF
--- a/src/commands/slash/setup-stats.ts
+++ b/src/commands/slash/setup-stats.ts
@@ -1,39 +1,41 @@
 import { SlashCommand } from "../../modules/handlers/HandlerBuilders.js";
-import { ChannelType, SlashCommandBuilder } from "discord.js";
+import { ChannelType, PermissionFlagsBits, SlashCommandBuilder } from "discord.js";
 import { logger } from "../../modules/utils/logger.js";
 
 export default new SlashCommand({
 	builder: new SlashCommandBuilder()
 		.setName("setup-stats")
-		.setDescription("Setear el canal de estadísticas del servidor"),
+		.setDescription("Setear el canal de estadísticas del servidor")
+		.setDefaultMemberPermissions(PermissionFlagsBits.Administrator),
 
 	async handler(): Promise<void> {
 		const guildId = this.context.guildId;
 		if (!guildId) { 
-			this.context.reply("No se ha podido obtener el ID del servidor"); 
+			await this.context.reply("No se ha podido obtener el ID del servidor"); 
 			logger.error("No se ha podido obtener el ID del servidor");
 			return; 
 		}
 		const guild = this.client.guilds.cache.get(guildId)
 		if (!guild) { 
-			this.context.reply("No se ha podido obtener el servidor"); 
+			await this.context.reply("No se ha podido obtener el servidor"); 
 			logger.error("No se ha podido obtener el servidor");
 			return; 
 		}
 		const categoryExists = guild.channels.cache.find(channel => channel.type === ChannelType.GuildCategory && channel.name === "Estadisticas")
 		if (categoryExists) {
-			this.context.reply("Ya existe una categoría de estadísticas en el servidor")
+			await this.context.reply("Ya existe una categoría de estadísticas en el servidor")
 			return
 		}
 		const category = await guild.channels.create({
 			name: "Estadisticas",
 			type: ChannelType.GuildCategory,
-			position: 1,
+			position: 0,
+		
             
 		})
 
 		if(!category) {
-			this.context.reply("No se ha podido crear la categoría de estadísticas")
+			await this.context.reply("No se ha podido crear la categoría de estadísticas")
 			logger.error("Error creating the category in the setup-stats command for the guild " + guild.name + " with ID " + guild.id)
 			return
 		}
@@ -78,6 +80,6 @@ export default new SlashCommand({
 			]
 		})
 
-		this.context.reply(`Canal de estadísticas creado en la categoría ${category}`)
+		await this.context.reply(`Canal de estadísticas creado en la categoría ${category}`)
 	}
 });

--- a/src/commands/slash/setup-stats.ts
+++ b/src/commands/slash/setup-stats.ts
@@ -32,6 +32,12 @@ export default new SlashCommand({
             
 		})
 
+		if(!category) {
+			this.context.reply("No se ha podido crear la categoría de estadísticas")
+			logger.error("Error creating the category in the setup-stats command for the guild " + guild.name + " with ID " + guild.id)
+			return
+		}
+
 		const totalMembers = guild.memberCount
 		const totalUsers = guild.members.cache.filter(member => !member.user.bot).size
 		const totalBots = guild.members.cache.filter(member => member.user.bot).size

--- a/src/commands/slash/setup-stats.ts
+++ b/src/commands/slash/setup-stats.ts
@@ -1,0 +1,77 @@
+import { SlashCommand } from "../../modules/handlers/HandlerBuilders.js";
+import { ChannelType, SlashCommandBuilder } from "discord.js";
+import { logger } from "../../modules/utils/logger.js";
+
+export default new SlashCommand({
+	builder: new SlashCommandBuilder()
+		.setName("setup-stats")
+		.setDescription("Setear el canal de estadísticas del servidor"),
+
+	async handler(): Promise<void> {
+		const guildId = this.context.guildId;
+		if (!guildId) { 
+			this.context.reply("No se ha podido obtener el ID del servidor"); 
+			logger.error("No se ha podido obtener el ID del servidor");
+			return; 
+		}
+		const guild = this.client.guilds.cache.get(guildId)
+		if (!guild) { 
+			this.context.reply("No se ha podido obtener el servidor"); 
+			logger.error("No se ha podido obtener el servidor");
+			return; 
+		}
+		const categoryExists = guild.channels.cache.find(channel => channel.type === ChannelType.GuildCategory && channel.name === "Estadisticas")
+		if (categoryExists) {
+			this.context.reply("Ya existe una categoría de estadísticas en el servidor")
+			return
+		}
+		const category = await guild.channels.create({
+			name: "Estadisticas",
+			type: ChannelType.GuildCategory,
+			position: 1,
+            
+		})
+
+		const totalMembers = guild.memberCount
+		const totalUsers = guild.members.cache.filter(member => !member.user.bot).size
+		const totalBots = guild.members.cache.filter(member => member.user.bot).size
+
+		await guild.channels.create({
+			name: "Miembros totales: " + totalMembers,
+			type: ChannelType.GuildVoice,
+			parent: category,
+			permissionOverwrites: [
+				{
+					id: guild.roles.everyone.id,
+					deny: ["Connect"]
+				}
+			]
+		})
+
+		await guild.channels.create({
+			name: "Miembros: " + totalUsers,
+			type: ChannelType.GuildVoice,
+			parent: category,
+			permissionOverwrites: [
+				{
+					id: guild.roles.everyone.id,
+					deny: ["Connect"]
+				}
+			]
+		})
+
+		await guild.channels.create({
+			name: "Bots: " + totalBots,
+			type: ChannelType.GuildVoice,
+			parent: category,
+			permissionOverwrites: [
+				{
+					id: guild.roles.everyone.id,
+					deny: ["Connect"]
+				}
+			]
+		})
+
+		this.context.reply(`Canal de estadísticas creado en la categoría ${category}`)
+	}
+});

--- a/src/events/GuildMemberAdd.ts
+++ b/src/events/GuildMemberAdd.ts
@@ -1,0 +1,38 @@
+import {Event} from "../modules/handlers/HandlerBuilders.js";
+import {ChannelType, Events, GuildMember} from "discord.js";
+import { logger } from "../modules/utils/logger.js";
+
+export default new Event({
+	event: Events.GuildMemberAdd,
+
+	handler(member: GuildMember): void {
+		logger.info(`The user ${member.user.tag} has joined the server ${member.guild.name} with ID ${member.guild.id} on ${member.joinedAt}, and their account was created on ${member.user.createdAt}`);
+		const guildId = member.guild.id;
+		const guild = this.client.guilds.cache.get(guildId)
+		const statsCategory = guild?.channels.cache.find(channel => channel.type === ChannelType.GuildCategory && channel.name === "Estadisticas")
+		if (!guild) { 
+			logger.error("Error getting the guild from the cache in the GuildMemberAdd event handler for the user " + member.user.tag + " with ID " + member.user.id);
+			return; 
+		}
+		if(member.user.bot) {
+			const botsChannel = guild.channels.cache.find(channel => channel.name.includes("Bots:") && channel.parentId === statsCategory?.id)
+			if(!botsChannel) {
+				logger.error("Error getting the Bots channel from the cache in the GuildMemberAdd event handler for the user " + member.user.tag + " with ID " + member.user.id);
+			}
+			botsChannel?.edit({name: "Bots: " + guild.members.cache.filter(member => member.user.bot).size})
+		}
+		else{
+			const usersChannel = guild.channels.cache.find(channel => channel.name.includes("Miembros:") && channel.parentId === statsCategory?.id)
+			if(!usersChannel) {
+				logger.error("Error getting the Miembros channel from the cache in the GuildMemberAdd event handler for the user " + member.user.tag + " with ID " + member.user.id);
+			}
+			usersChannel?.edit({name: "Miembros: " + guild.members.cache.filter(member => !member.user.bot).size})
+		}
+		const allMembersChannel = guild.channels.cache.find(channel => channel.name.includes("Miembros totales") && channel.parentId === statsCategory?.id)
+		if(!allMembersChannel) {
+			logger.error("Error getting the Miembros totales channel from the cache in the GuildMemberAdd event handler for the user " + member.user.tag + " with ID " + member.user.id);
+		}
+		allMembersChannel?.edit({name: "Miembros totales: " + guild.memberCount})
+		
+	}
+});

--- a/src/events/GuildMemberRemove.ts
+++ b/src/events/GuildMemberRemove.ts
@@ -1,14 +1,13 @@
 import {Event} from "../modules/handlers/HandlerBuilders.js";
-import {Events, GuildMember} from "discord.js";
+import { Events, GuildMember} from "discord.js";
 import { logger } from "../modules/utils/logger.js";
 import updateStats from "../modules/utils/updateStats.js";
 
 export default new Event({
-	event: Events.GuildMemberAdd,
+	event: Events.GuildMemberRemove,
 
 	async handler(member: GuildMember): Promise<void> {
-		logger.info(`The user ${member.user.tag} has joined the server ${member.guild.name} with ID ${member.guild.id} on ${member.joinedAt}, and their account was created on ${member.user.createdAt}`);
+		logger.info(`The user ${member.user.tag} has left the server ${member.guild.name} with ID ${member.guild.id} on ${member.joinedAt}, and their account was created on ${member.user.createdAt}`);
 		await updateStats(this, member)
-	
 	}
 });

--- a/src/modules/utils/updateStats.ts
+++ b/src/modules/utils/updateStats.ts
@@ -4,12 +4,13 @@ import { BaseContext } from "../handlers/HandlerContext.js";
 
 export default async function updateStats(context: BaseContext, member: GuildMember) {
 	const guildId = member.guild.id;
-	const guild = context.client.guilds.cache.get(guildId)
-	const statsCategory = guild?.channels.cache.find(channel => channel.type === ChannelType.GuildCategory && channel.name === "Estadisticas")
+	const guild = await context.client.guilds.fetch(guildId);
 	if (!guild) { 
 		logger.error("Error getting the guild from the cache in the GuildMemberAdd event handler for the user " + member.user.tag + " with ID " + member.user.id);
 		return; 
 	}
+	const statsCategory = guild.channels.cache.find(channel => channel.type === ChannelType.GuildCategory && channel.name === "Estadisticas")
+
 	if(member.user.bot) {
 		const botsChannel = guild.channels.cache.find(channel => channel.name.includes("Bots:") && channel.parentId === statsCategory?.id)
 		if(!botsChannel) {

--- a/src/modules/utils/updateStats.ts
+++ b/src/modules/utils/updateStats.ts
@@ -1,0 +1,38 @@
+import { ChannelType, GuildMember } from "discord.js";
+import { logger } from "./logger.js";
+import { BaseContext } from "../handlers/HandlerContext.js";
+
+export default async function updateStats(context: BaseContext, member: GuildMember) {
+	const guildId = member.guild.id;
+	const guild = context.client.guilds.cache.get(guildId)
+	const statsCategory = guild?.channels.cache.find(channel => channel.type === ChannelType.GuildCategory && channel.name === "Estadisticas")
+	if (!guild) { 
+		logger.error("Error getting the guild from the cache in the GuildMemberAdd event handler for the user " + member.user.tag + " with ID " + member.user.id);
+		return; 
+	}
+	if(member.user.bot) {
+		const botsChannel = guild.channels.cache.find(channel => channel.name.includes("Bots:") && channel.parentId === statsCategory?.id)
+		if(!botsChannel) {
+			logger.error("Error getting the Bots channel from the cache in the GuildMemberAdd event handler for the user " + member.user.tag + " with ID " + member.user.id);
+			return;
+		}
+		await botsChannel.edit({name: "Bots: " + guild.members.cache.filter(member => member.user.bot).size})
+	}
+	else{
+		const usersChannel = guild.channels.cache.find(channel => channel.name.includes("Miembros:"))
+        
+		if(!usersChannel) {
+			logger.error("Error getting the Miembros channel from the cache in the GuildMemberAdd event handler for the user " + member.user.tag + " with ID " + member.user.id);
+			return;
+		}
+		await usersChannel.edit({name: "Miembros: " + guild.members.cache.filter(member => !member.user.bot).size})
+	}
+	const allMembersChannel = guild.channels.cache.find(channel => channel.name.includes("Miembros totales:"))
+	if(!allMembersChannel) {
+		logger.error("Error getting the Miembros totales channel from the cache in the GuildMemberAdd event handler for the user " + member.user.tag + " with ID " + member.user.id);
+		return;
+	}
+	await allMembersChannel.edit({name: "Miembros totales: " + guild.memberCount})
+	return 
+}
+


### PR DESCRIPTION
## Description

Implemented a new slash command `setup-stats` to set up server statistics in a Discord channel. This command creates a new category named "Statistics" if it doesn't already exist and then creates three voice channels within that category: 
- Total Members
- Members (excluding bots)
- Bots

The voice channels display the respective counts of total members, human members, and bot members in the server. Additionally, the command sets permissions to disallow anyone from connecting to these voice channels except server administrators.

This PR aims to enhance server management by providing a convenient way to visualize server statistics in Discord.
