### PR TITLE
Status changing

### DIFF
--- a/src/events/Ready.ts
+++ b/src/events/Ready.ts
@@ -16,7 +16,7 @@ export default new Event({
 		let currentStatus: number = 0;
 		function changeStatus(this: EventContext): void {
 			this.client.user!.setActivity(
-				presences[currentStatus + 1 === presences.length ? 0 : currentStatus++]
+presences[++currentStatus === presences.length ? 0 : currentStatus]
 			);
 		}
 

--- a/src/events/Ready.ts
+++ b/src/events/Ready.ts
@@ -1,11 +1,28 @@
 import {Event} from "../modules/handlers/HandlerBuilders.js";
-import {Events} from "discord.js";
+import {ActivityOptions, ActivityType, Events} from "discord.js";
 import {logger} from "../modules/utils/logger.js";
+import {EventContext} from "../modules/handlers/HandlerContext.js";
+
+const presences: ActivityOptions[] = [
+	{ name: "your SaaS projects", type: ActivityType.Watching },
+	{ name: "for your contributions", type: ActivityType.Listening },
+	{ name: "with your SaaS project", type: ActivityType.Playing }
+];
 
 export default new Event({
 	event: Events.ClientReady,
 
 	handler(): void {
+		let currentStatus: number = 0;
+		function changeStatus(this: EventContext): void {
+			this.client.user!.setActivity(
+				presences[currentStatus + 1 === presences.length ? 0 : currentStatus++]
+			);
+		}
+
+		setInterval(changeStatus.bind(this), 3600000 * 5);
+		changeStatus.call(this);
+
 		logger.info("Client ready!");
 	}
 });


### PR DESCRIPTION
# Description

This PR modifies the ready event from this bot and adds changing status functionality every 5 hours, you may change the `presences` array declared in the top level of the module to change what status and status type will be shown.

```ts
const presences: ActivityOptions[] = [
	{ name: "your SaaS projects", type: ActivityType.Watching },
	{ name: "for your contributions", type: ActivityType.Listening },
	{ name: "with your SaaS project", type: ActivityType.Playing }
];
```

intends to solve #12