### PR TITLE
Code interpreter

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -2,6 +2,37 @@
   <profile version="1.0">
     <option name="myName" value="Project Default" />
     <inspection_tool class="Eslint" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="HttpUrlsUsage" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <option name="ignoredUrls">
+        <list>
+          <option value="http://0.0.0.0" />
+          <option value="http://127.0.0.1" />
+          <option value="http://activemq.apache.org/schema/" />
+          <option value="http://api.paiza.io" />
+          <option value="http://cxf.apache.org/schemas/" />
+          <option value="http://java.sun.com/" />
+          <option value="http://javafx.com/fxml" />
+          <option value="http://javafx.com/javafx/" />
+          <option value="http://json-schema.org/draft" />
+          <option value="http://localhost" />
+          <option value="http://maven.apache.org/POM/" />
+          <option value="http://maven.apache.org/xsd/" />
+          <option value="http://primefaces.org/ui" />
+          <option value="http://schema.cloudfoundry.org/spring/" />
+          <option value="http://schemas.xmlsoap.org/" />
+          <option value="http://tiles.apache.org/" />
+          <option value="http://www.ibm.com/webservices/xsd" />
+          <option value="http://www.jboss.com/xml/ns/" />
+          <option value="http://www.jboss.org/j2ee/schema/" />
+          <option value="http://www.springframework.org/schema/" />
+          <option value="http://www.springframework.org/security/tags" />
+          <option value="http://www.springframework.org/tags" />
+          <option value="http://www.thymeleaf.org" />
+          <option value="http://www.w3.org/" />
+          <option value="http://xmlns.jcp.org/" />
+        </list>
+      </option>
+    </inspection_tool>
     <inspection_tool class="JSAnnotator" enabled="false" level="ERROR" enabled_by_default="false" />
   </profile>
 </component>

--- a/src/commands/code-interpreter/slash/RunCode.ts
+++ b/src/commands/code-interpreter/slash/RunCode.ts
@@ -1,0 +1,136 @@
+import {SlashCommand} from "../../../modules/handlers/HandlerBuilders.js";
+import {Attachment, EmbedBuilder, SlashCommandBuilder} from "discord.js";
+import {CreateRunnerResponse, GetRunnerDetails} from "../utils/ApiTypes.js";
+import {checkRunnerDetails, checkRunnerStatus, getResultEmbed, extensions} from "../utils/RunnerUtils.js";
+
+export default new SlashCommand({
+	builder: new SlashCommandBuilder()
+		.setName("run-code")
+		.setDescription("Code running category")
+		.addSubcommand(c => c
+			.setName("from-file")
+			.setDescription("Run code from a file you upload")
+			.addAttachmentOption(o => o
+				.setName("file")
+				.setDescription("The file to run the code from, the language will be inferred from the file extension")
+				.setRequired(true)
+			)
+			.addStringOption(o => o
+				.setName("stdin")
+				.setDescription("Pass input to the code interpreter.")
+			)
+		)
+		.addSubcommand(c => c
+			.setName("from-input")
+			.setDescription("Run code directly from your command input")
+			.addStringOption(o => o
+				.setName("code")
+				.setDescription("The script to run.")
+				.setRequired(true)
+			)
+			.addStringOption(o => o
+				.setName("language")
+				.setDescription("The coding language the script is written on")
+				.setRequired(true)
+				.addChoices(
+					{name: "C | C17/clang10", value: "c"},
+					{name: "C++ | C++17/clang10", value: "cpp"},
+					{name: "Java | OpenJDK18", value: "java"},
+					{name: "Kotlin | 1.7.10/JRE18", value: "kotlin"},
+					{name: "Swift | 5.6.2", value: "swift"},
+					{name: "C# | Mono 6", value: "csharp"},
+					{name: "Go | 1.19", value: "go"},
+					{name: "Python 3 | 3.8.10", value: "python3"},
+					{name: "Ruby | 3.1.2p20", value: "ruby"},
+					{name: "PHP | 8.1.9 cli", value: "php"},
+					{name: "BASH | 5.0.17", value: "bash"},
+					{name: "RLang | 3.6.3", value: "r"},
+					{name: "JavaScript | NodeJS 16.17.0", value: "javascript"},
+					{name: "Visual Basic | Mono 6", value: "vb"},
+					{name: "BrainFuck", value: "brainfuck"},
+					{name: "Cobol | cobc 2.2.0", value: "cobol"},
+					{name: "F# | F# Interactive 4.0", value: "fsharp"},
+					{name: "Elixir | 1.12.3", value: "elixir"},
+					{name: "Rust | rustc 1.59.0", value: "rust"},
+					{name: "TypeScript | 4.8.2", value: "typescript"}
+				)
+			)
+			.addStringOption(o => o
+				.setName("stdin")
+				.setDescription("Pass input to the code interpreter.")
+			)
+		),
+
+	async handler(): Promise<void> {
+		let code: string;
+		let language: string;
+		const stdin: string | null = this.context.options.getString("stdin");
+
+		if (this.context.options.getSubcommand() === "from-file") {
+			const file: Attachment = this.context.options.getAttachment("file")!;
+			code = await fetch(file.url).then(f => f.text());
+
+			const splitName: string[] = file.name.split('.');
+
+			if (splitName.length < 2
+				|| !Object.keys(extensions).includes(splitName[splitName.length - 1])) {
+
+				const unknownLangEmbed: EmbedBuilder = new EmbedBuilder()
+					.setTitle("Invalid language")
+					.setDescription("Inferred language is not valid, valid languages include:\n\n```" +
+						Object.keys(extensions).map(e => `*.${e}`).join(", ") +
+						"```"
+					)
+					.setColor("#FF0000");
+
+				await this.context.reply({
+					embeds: [unknownLangEmbed],
+					ephemeral: true
+				});
+				return;
+			}
+
+			language = extensions[splitName[splitName.length - 1]];
+		} else {
+			code = this.context.options.getString("code")!;
+			language = this.context.options.getString("language")!;
+		}
+
+		await this.context.deferReply();
+
+		const createRunnerResult: CreateRunnerResponse = await fetch("http://api.paiza.io/runners/create?"
+			+ `source_code=${encodeURIComponent(code)}&`
+			+ `language=${encodeURIComponent(language)}&`
+			+ "api_key=guest&"
+			+ (stdin !== null ? `input=${encodeURIComponent(stdin)}` : ""),
+		{ method: "POST" }
+		)
+			.then(r => r.json());
+
+		setTimeout(async (): Promise<void> => {
+			const checkRunnerResult: CreateRunnerResponse = await checkRunnerStatus(createRunnerResult.id);
+
+			if (checkRunnerResult.status === "running") {
+				const timeoutEmbed: EmbedBuilder = new EmbedBuilder()
+					.setTitle("Long running session!")
+					.setDescription(
+						"Looks like this session is going to take some time," +
+						"but don't worry you can still use the </run-code get-output:1221193746209701920>" +
+						"command and check the output for this session once it's finished!"
+					)
+					.addFields(
+						{name: "Session ID", value: checkRunnerResult.id, inline: true},
+						{name: "Status", value: checkRunnerResult.status, inline: true}
+					)
+					.setColor("#FFA500");
+
+				await this.context.editReply({embeds: [timeoutEmbed]});
+				return;
+			}
+
+			const getRunnerResult: GetRunnerDetails = await checkRunnerDetails(createRunnerResult.id);
+
+			await this.context.editReply({embeds: [getResultEmbed(getRunnerResult)]});
+		}, 3000);
+	}
+});

--- a/src/commands/code-interpreter/slash/SessionResult.ts
+++ b/src/commands/code-interpreter/slash/SessionResult.ts
@@ -1,0 +1,49 @@
+import {SlashCommand} from "../../../modules/handlers/HandlerBuilders.js";
+import {EmbedBuilder, SlashCommandBuilder} from "discord.js";
+import {CreateRunnerResponse} from "../utils/ApiTypes.js";
+import {checkRunnerDetails, checkRunnerStatus, getResultEmbed} from "../utils/RunnerUtils.js";
+
+export default new SlashCommand({
+	builder: new SlashCommandBuilder()
+		.setName("code-session")
+		.setDescription("Get data from code sessions")
+		.addSubcommand(c => c
+			.setName("get-result")
+			.setDescription("Get result from a long running session")
+			.addStringOption(o => o
+				.setName("id")
+				.setDescription("The session ID")
+				.setRequired(true)
+			)
+		),
+
+	async handler(): Promise<void> {
+		await this.context.deferReply();
+		const sessionId: string = this.context.options.getString("id")!;
+
+		const status: CreateRunnerResponse = await checkRunnerStatus(sessionId);
+
+		if (status.status === "running") {
+			const timeoutEmbed: EmbedBuilder = new EmbedBuilder()
+				.setTitle("On it!")
+				.setDescription(
+					"This runner is still running," +
+					"please, wait and run this command again in a few seconds"
+				)
+				.addFields(
+					{name: "Session ID", value: status.id, inline: true},
+					{name: "Status", value: status.status, inline: true}
+				)
+				.setColor("#FFA500")
+
+			await this.context.editReply({
+				embeds: [timeoutEmbed]
+			});
+			return;
+		}
+
+		await this.context.editReply({
+			embeds: [getResultEmbed(await checkRunnerDetails(sessionId))]
+		});
+	}
+})

--- a/src/commands/code-interpreter/utils/ApiTypes.ts
+++ b/src/commands/code-interpreter/utils/ApiTypes.ts
@@ -1,0 +1,19 @@
+
+export interface CreateRunnerResponse {
+	id: string;
+	status: "running" | "completed";
+}
+
+export interface GetRunnerDetails {
+	id: string;
+
+	build_stderr: string | null;
+	build_stdout: string | null;
+	build_exit_code: number;
+	build_result: "success" | "failure" | "error";
+
+	stdout: string | null;
+	stderr: string | null;
+	result: "success" | "failure" | "error";
+	exit_code: number;
+}

--- a/src/commands/code-interpreter/utils/RunnerUtils.ts
+++ b/src/commands/code-interpreter/utils/RunnerUtils.ts
@@ -1,0 +1,59 @@
+import {CreateRunnerResponse, GetRunnerDetails} from "./ApiTypes.js";
+import {EmbedBuilder} from "discord.js";
+
+export const extensions: Record<string, string> = {
+	"c": "c",
+	"cpp": "cpp",
+	"java": "java",
+	"kt": "kotlin",
+	"swift": "swift",
+	"cs": "csharp",
+	"go": "go",
+	"py": "python3",
+	"rb": "ruby",
+	"php": "php",
+	"sh": "bash",
+	"r": "r",
+	"js": "javascript",
+	"vb": "vb",
+	"bf": "brainfuck",
+	"cob": "cobol",
+	"fs": "fsharp",
+	"ex": "elixir",
+	"rs": "rust",
+	"ts": "typescript"
+}
+
+export async function checkRunnerDetails(id: string): Promise<GetRunnerDetails> {
+	return await fetch(`http://api.paiza.io/runners/get_details?id=${encodeURIComponent(id)}&api_key=guest`)
+		.then(r => r.json());
+}
+
+export async function checkRunnerStatus(id: string): Promise<CreateRunnerResponse> {
+	return await fetch(`http://api.paiza.io/runners/get_status?id=${encodeURIComponent(id)}&api_key=guest`)
+		.then(r => r.json());
+}
+
+export function getResultEmbed(details: GetRunnerDetails): EmbedBuilder {
+	if (details.build_result !== "success" && details.build_result !== null) {
+		return new EmbedBuilder()
+			.setTitle("Build error")
+			.setDescription(`Session ID: \`${details.id}\`\n\`\`\`${details.build_stderr ?? details.build_stdout}\`\`\``)
+			.setColor("#FF0000")
+			.setFooter({text: `Exited with code: ${details.build_exit_code}`});
+	}
+
+	if (details.result !== "success") {
+		return new EmbedBuilder()
+			.setTitle("Runtime error")
+			.setDescription(`Session ID: \`${details.id}\`\n\`\`\`${details.stderr ?? details.stdout}\`\`\``)
+			.setColor("#FF0000")
+			.setFooter({text: `Exited with code: ${details.exit_code}`});
+	}
+
+	return new EmbedBuilder()
+		.setTitle("Success")
+		.setDescription(`Session ID: \`${details.id}\`\n\`\`\`${details.stdout}\`\`\``)
+		.setColor("#00B000")
+		.setFooter({text: `Exited with code: ${details.exit_code}`});
+}

--- a/src/modules/handlers/HandlerParameters.ts
+++ b/src/modules/handlers/HandlerParameters.ts
@@ -1,5 +1,11 @@
-import {Events, Interaction, SlashCommandBuilder} from "discord.js";
-import {BaseContext, ButtonContext, CommandContext, EventContext, SelectMenuContext} from "./HandlerContext.js";
+import {Events, Interaction, SlashCommandSubcommandsOnlyBuilder} from "discord.js";
+import {
+	BaseContext,
+	ButtonContext,
+	CommandContext,
+	EventContext,
+	SelectMenuContext
+} from "./HandlerContext.js";
 
 export interface BaseParameters<TThis extends BaseContext> {
 	handler: (this: TThis, ...params: any[]) => Promise<void> | void;
@@ -8,7 +14,7 @@ export interface BaseParameters<TThis extends BaseContext> {
 export interface CommandParameters<TInteraction extends Interaction>
 	extends BaseParameters<CommandContext<TInteraction>> {
 
-	builder: SlashCommandBuilder;
+	builder: SlashCommandSubcommandsOnlyBuilder;
 }
 
 export interface EventParameters


### PR DESCRIPTION
# Description
This PR comes with a code interpreter that runs a lot of common languages, even Brainfuck, it's contained in a module called `code-interpreter` inside the `commands` folder.

# Features
![image](https://github.com/DiscordSaaSBot/SaaSBot/assets/79871802/5d1c58f4-bb9d-49bb-9032-5178fe537043)
![image](https://github.com/DiscordSaaSBot/SaaSBot/assets/79871802/a3162a55-1bb4-41ae-a6a1-a904751bce5b)

The command comes with the ability to run commands from a file you may upload or directly write with command parameters.

# About vulnerabilities
This command uses the [Paiza API](https://paiza.io/es), so all the code is run by them, as this PR can't in any way run that many languages being this small...

# Supported languages
- C | C17/clang10
- C++ | C++17/clang10
- Java | OpenJDK18
- Kotlin | 1.7.10/JRE18
- Swift | 5.6.2
- C# | Mono 6
- Go | 1.19
- Python 3 | 3.8.10
- Ruby | 3.1.2p20
- PHP | 8.1.9 cli
- BASH | 5.0.17
- RLang | 3.6.3
- JavaScript | NodeJS 16.17.0
- Visual Basic | Mono 6
- BrainFuck
- Cobol | cobc 2.2.0
- F# | F# Interactive 4.0
- Elixir | 1.12.3
- Rust | rustc 1.59.0
- TypeScript | 4.8.2

# Other fixes
This PR also fixes a problem with the handlers, where you couldn't add sub commands or options while building a command.